### PR TITLE
Remove org.apache.camel.springboot:camel-spring-boot-bom - it is not necessary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,14 +100,6 @@
 				<scope>import</scope>
 			</dependency>
 
-                        <dependency>
-                                <groupId>org.apache.camel.springboot</groupId>
-                                <artifactId>camel-spring-boot-bom</artifactId>
-                                <version>${camel-spring-boot-version}</version>
-                                <type>pom</type>
-                                <scope>import</scope>
-                        </dependency>
-
 			<dependency>
 				<groupId>org.apache.camel</groupId>
 				<artifactId>camel-bom</artifactId>


### PR DESCRIPTION
Added this in when we were getting errors from com.redhat.springboot bom because it included the wrong version of org.apache.camel.springboot:camel-spring-boot-bom.    Now that the version of org.apache.camel.springboot:camel-spring-boot-bom is correct in com.redhat.springboot bom, the bom import is not necessary.