### PR TITLE
Specify spring-boot-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,11 @@
 					<artifactId>fabric8-maven-plugin</artifactId>
 					<version>${fabric8-maven-plugin-version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>${spring-boot-version}</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
When executing the quickstarts I would get

`'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing`

This would result in maven fetching the latest version which in turn would cause quickstarts to **fail** if you had a version that would require Java 17+ like 3.1.0-M2....

Thanks !