### PR TITLE
Draft: install SAP libs in the Maven local repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 	</licenses>
 
 	<properties>
+		<lib.directory>${basedir}/lib</lib.directory>
+		<spring-boot.run.directories>${lib.directory}/*</spring-boot.run.directories>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -137,7 +139,48 @@
 		</resources>
 		<pluginManagement>
 			<plugins>
-
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>copy-sap-libs</id>
+							<phase>process-sources</phase>
+							<goals>
+								<goal>copy</goal>
+							</goals>
+							<configuration>
+								<stripVersion>true</stripVersion>
+								<outputDirectory>${lib.directory}</outputDirectory>
+								<artifactItems>
+									<artifactItem>
+										<groupId>com.sap.conn.jco</groupId>
+										<artifactId>sapjco3</artifactId>
+										<version>${sapjco3-version}</version>
+										<type>${envType}</type>
+										<classifier>${envClassifier}</classifier>
+										<overWrite>true</overWrite>
+										<destFileName>${native.lib.filename}.${envType}</destFileName>
+									</artifactItem>
+									<artifactItem>
+										<groupId>com.sap.conn.jco</groupId>
+										<artifactId>sapjco3</artifactId>
+										<version>${sapjco3-version}</version>
+										<overWrite>true</overWrite>
+										<destFileName>sapjco3.jar</destFileName>
+									</artifactItem>
+									<artifactItem>
+										<groupId>com.sap.conn.idoc</groupId>
+										<artifactId>sapidoc3</artifactId>
+										<version>${sapidoc3-version}</version>
+										<overWrite>true</overWrite>
+										<destFileName>sapidoc3.jar</destFileName>
+									</artifactItem>
+								</artifactItems>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
@@ -201,6 +244,19 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-maven-plugin</artifactId>
 					<version>${spring-boot-version}</version>
+					<configuration>
+					<!-- TODO: remove this once camel-sap-starter doesn't include these in transitive dependencies -->
+						<excludes>
+							<exclude>
+								<groupId>com.sap.conn.idoc</groupId>
+								<artifactId>sapidoc3</artifactId>
+							</exclude>
+							<exclude>
+								<groupId>com.sap.conn.jco</groupId>
+								<artifactId>sapjco3</artifactId>
+							</exclude>
+						</excludes>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -305,6 +361,202 @@
 			<id>snapshots</id>
 			<properties>
 				<snapshop-build>redhat-7.0.0.redhat-SNAPSHOT</snapshop-build>
+			</properties>
+		</profile>
+		<profile>
+			<id>win-i386</id>
+			<activation>
+				<os>
+					<name>windows</name>
+					<arch>i386</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-i686</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win-x86</id>
+			<activation>
+				<os>
+					<name>windows</name>
+					<arch>x86</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-i686</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win-x86_64</id>
+			<activation>
+				<os>
+					<name>windows</name>
+					<arch>x86_64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-x86_64</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win10-x86_64</id>
+			<activation>
+				<os>
+					<name>windows 10</name>
+					<arch>x86_64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-x86_64</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win32-amd64</id>
+			<activation>
+				<os>
+					<name>windows</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-x86_64</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win10-amd64</id>
+			<activation>
+				<os>
+					<name>windows 10</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-x86_64</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-i386</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>i386</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>linux-i686</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-x86</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>x86</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>linux-i686</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-x86_64</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>x86_64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>linux-x86_64</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-amd64</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>linux-x86_64</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>macosx-i386</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+					<arch>i386</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>macosx-i686</envClassifier>
+				<envType>dylib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>macosx-x86</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+					<arch>x86</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>macosx-i686</envClassifier>
+				<envType>dylib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>macosx-x86_64</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+					<arch>x86_64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>macosx-x86_64</envClassifier>
+				<envType>dylib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>macosx-amd64</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>macosx-x86_64</envClassifier>
+				<envType>dylib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,11 @@
 					<artifactId>fabric8-maven-plugin</artifactId>
 					<version>${fabric8-maven-plugin-version}</version>
 				</plugin>
+				<plugin>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-maven-plugin</artifactId>
+					<version>${spring-boot-version}</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/spring-boot/README.md
+++ b/spring-boot/README.md
@@ -72,5 +72,40 @@ To run these quick starts you will need:
 * Maven 3.6.2 or higher
 * JDK 11
 * Red Hat Build of Camel Spring Boot
-* SAP JCo3 and IDoc3 libraries (sapjco3.jar, sapidoc3.jar and JCo native library for your OS platform)
+* SAP JCo3 and IDoc3 libraries (sapjco3.jar, sapidoc3.jar and JCo native library for your OS platform) installed in your local Maven repository (see how to at the end)
 * SAP instance with [Flight Data Application](http://help.sap.com/saphelp_erp60_sp/helpdata/en/db/7c623cf568896be10000000a11405a/content.htm) setup.
+
+---
+Install SAP libraries in your local Maven repository
+---
+
+To install your three SAP libraries in your Maven repository you will need to run three commands using Maven:
+
+
+mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.1.4 -Dpackaging=jar -Dfile=sapjco3.jar
+
+mvn install:install-file -DgroupId=com.sap.conn.idoc -DartifactId=sapidoc3 -Dversion=3.1.1 -Dpackaging=jar -Dfile=sapidoc3.jar
+
+Installing the JCo native library will depend on the Operating System and architecture you are running. For example: 
+
+for Linux x86 64 bit:
+
+mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.1.4 -Dclassifier=linux-x86_64 -Dpackaging=so -Dfile=libsapjco3.so
+
+MacOS 64 bit:
+
+mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.1.4 -Dclassifier=macosx-x86_64 -Dpackaging=dylib -Dfile=libsapjco3.dylib
+
+Windows 64 bit
+
+mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.1.4 -Dclassifier=win-x86_64 -Dpackaging=dll -Dfile=sapjco3.dll
+
+For more architectures please see the [pom.xml](pom.xml#L376)
+
+When using different version please also change the version in [pom.xml](pom.xml#L46)
+
+
+
+
+
+

--- a/spring-boot/sap-idoc-destination-spring-boot/lib/README.txt
+++ b/spring-boot/sap-idoc-destination-spring-boot/lib/README.txt
@@ -1,1 +1,0 @@
-Place your copies of the IDoc and JCo libraries and the JCo native library for your OS platform in this directory.

--- a/spring-boot/sap-idoc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-idoc-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-idoclist-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-idoclist-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-idoclist-server-spring-boot/pom.xml
+++ b/spring-boot/sap-idoclist-server-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-qidoc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qidoc-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-qidoclist-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qidoclist-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-qrfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qrfc-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-srfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-srfc-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-srfc-server-spring-boot/pom.xml
+++ b/spring-boot/sap-srfc-server-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-trfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-trfc-destination-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/spring-boot/sap-trfc-server-spring-boot/pom.xml
+++ b/spring-boot/sap-trfc-server-spring-boot/pom.xml
@@ -57,20 +57,6 @@
 			<groupId>org.fusesource</groupId>
 			<artifactId>camel-sap-starter</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.jco</groupId>
-			<artifactId>sapjco3</artifactId>
-			<version>${sapjco3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.conn.idoc</groupId>
-			<artifactId>sapidoc3</artifactId>
-			<version>${sapidoc3-version}</version>
-			<scope>system</scope>
-			<systemPath>${basedir}/lib/sapidoc3.jar</systemPath>
-		</dependency>
 	</dependencies>
 	<build>
 		<defaultGoal>spring-boot:run</defaultGoal>
@@ -82,7 +68,10 @@
 		</resources>
 
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>


### PR DESCRIPTION
DO NOT MERGE, DRAFT!

@cunningt @luigidemasi 

As we discussed, this is a PR that demonstrates users installing the three SAP libraries in their Maven repository instead of using a lib folder. So for example using version _3.1.4_ for sapjco and _3.1.1_ for sapidoc on Linux x86 64 bit the user would have to run three commands:

1. mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.1.4 -Dpackaging=jar -Dfile=sapjco3.jar

2. mvn install:install-file -DgroupId=com.sap.conn.idoc -DartifactId=sapidoc3 -Dversion=3.1.1 -Dpackaging=jar -Dfile=sapidoc3.jar

3. mvn install:install-file -DgroupId=com.sap.conn.jco -DartifactId=sapjco3 -Dversion=3.1.4 -Dclassifier=linux-x86_64 -Dpackaging=so -Dfile=libsapjco3.so

Some drawbacks compared to using the lib folder strategy:

1. If the user uses a different version for sapjco or sapidoc, he has to update the [pom.xml](https://github.com/jboss-fuse/sap-quickstarts/compare/camel-3.20.1-branch...jboss-fuse:sap-quickstarts:sap-libs?expand=1#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R159)
2. The command for the native library is OS dependent so error prone. If a different classifier was used the pom.xml also has to be updated.
3. The standalone version of the quickstarts (not sure if we should keep them here or not as this is for SpringBoot) uses the [Camel Maven Plugin](https://camel.apache.org/manual/camel-maven-plugin.html) which doesn't have an option to add extra dependencies. **We would therefore have to use the lib folder strategy.**

Given those drawbacks I think I prefer keeping the lib folder strategy but maybe I'm missing something. We can improve on it as @luigidemasi suggested and use a single lib folder too.

Let me know what you think!





