### PR TITLE
Add openshift profile to allow openshift deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target
 sapidoc3.jar
 sapjco3.jar
+libsapjco3.so
 libsapjco3.dylib
 *.iml
 *.ipr

--- a/spring-boot/sap-idoc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-idoc-destination-spring-boot/pom.xml
@@ -25,6 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../..</relativePath>
 	</parent>
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_idoc_destination_spring_boot.Application</main.class>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -65,6 +68,15 @@
 			<systemPath>${basedir}/lib/sapjco3.jar</systemPath>
 		</dependency>
 		<dependency>
+			<groupId>com.sap.conn.jco</groupId>
+			<artifactId>sapjco3</artifactId>
+			<version>${sapjco3-version}</version>
+			<classifier>linux-i686</classifier>
+			<type>so</type>
+			<scope>system</scope>
+			<systemPath>${basedir}/lib/libsapjco3.so</systemPath>
+		</dependency>
+		<dependency>
 			<groupId>com.sap.conn.idoc</groupId>
 			<artifactId>sapidoc3</artifactId>
 			<version>${sapidoc3-version}</version>
@@ -80,9 +92,7 @@
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
@@ -93,6 +103,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+    				<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -109,8 +138,73 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
-
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-idoc-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-idoc-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-idoclist-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-idoclist-destination-spring-boot/pom.xml
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_idoclist_destination_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -80,9 +82,7 @@
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
@@ -93,6 +93,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+    				<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +130,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-idoclist-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-idoclist-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-idoclist-server-spring-boot/pom.xml
+++ b/spring-boot/sap-idoclist-server-spring-boot/pom.xml
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_idoclist_server_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -93,6 +95,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+    				<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -112,6 +133,72 @@
 
 
 		</plugins>
-
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-idoclist-server-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-idoclist-server-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-qidoc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qidoc-destination-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_qidoc_destination_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -80,9 +82,7 @@
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
@@ -93,6 +93,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +130,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-qidoc-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-qidoc-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-qidoclist-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qidoclist-destination-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_qidoc_destination_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -80,9 +82,7 @@
 				<filtering>true</filtering>
 			</resource>
 		</resources>
-
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
@@ -93,6 +93,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +130,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-qidoclist-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-qidoclist-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-qrfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qrfc-destination-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_qrfc_destination_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -93,6 +95,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +132,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-qrfc-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-qrfc-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-srfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-srfc-destination-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_srfc_destination_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -93,6 +95,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +132,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-srfc-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-srfc-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-srfc-server-spring-boot/pom.xml
+++ b/spring-boot/sap-srfc-server-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_srfc_server_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -93,6 +95,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +132,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-srfc-server-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-srfc-server-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-trfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-trfc-destination-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_trfc_destination_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -93,6 +95,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +132,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-trfc-destination-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-trfc-destination-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar

--- a/spring-boot/sap-trfc-server-spring-boot/pom.xml
+++ b/spring-boot/sap-trfc-server-spring-boot/pom.xml
@@ -9,8 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -25,7 +25,9 @@
 		<version>3.20.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-
+	<properties>
+		<main.class>com.redhat.quickstarts.fuse.sap_trfc_server_spring_boot.Application</main.class>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>
@@ -93,6 +95,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/classes</outputDirectory>
+					<resources>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>application.properties</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+						<resource>
+							<directory>src/main/resources</directory>
+							<includes>
+								<include>classpath</include>
+							</includes>
+							<filtering>true</filtering>
+						</resource>
+					</resources>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.camel</groupId>
@@ -111,4 +132,71 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>openshift</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.jkube</groupId>
+						<artifactId>openshift-maven-plugin</artifactId>
+						<configuration>
+							<resources>
+								<controller>
+									<env>
+										<AB_PROMETHEUS_OFF>true</AB_PROMETHEUS_OFF>
+										<AB_JOLOKIA_OFF>true</AB_JOLOKIA_OFF>
+										<AB_ENABLED>false</AB_ENABLED>
+										<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>
+										<JAVA_OPTIONS>-Dloader.main=${main.class}</JAVA_OPTIONS>
+									</env>
+								</controller>
+							</resources>
+							<images>
+								<image>
+									<name>camel/actuator-http-metric</name>
+									<build>
+										<from>quay.io/jkube/jkube-java:0.0.19</from>
+										<assembly>
+											<mode>dir</mode>
+											<targetDir>/deployments</targetDir>
+											<layers>
+												<layer>
+													<id>lib</id>
+													<fileSets>
+														<fileSet>
+															<directory>${project.build.directory}/classes</directory>
+															<outputDirectory>.</outputDirectory>
+															<fileMode>0640</fileMode>
+															<includes>classpath</includes>
+														</fileSet>
+														<fileSet>
+															<directory>${project.basedir}/lib</directory>
+															<outputDirectory>lib</outputDirectory>
+															<fileMode>0640</fileMode>
+														</fileSet>
+													</fileSets>
+												</layer>
+											</layers>
+										</assembly>
+										<ports>
+											<port>8080</port>
+										</ports>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>resource</goal>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/spring-boot/sap-trfc-server-spring-boot/src/main/resources/classpath
+++ b/spring-boot/sap-trfc-server-spring-boot/src/main/resources/classpath
@@ -1,0 +1,1 @@
+/deployments/${project.build.finalName}.jar:/deployments/lib/sapidoc3.jar:/deployments/lib/sapjco3.jar


### PR DESCRIPTION
I'm adding openshift profiles to the spring-boot quickstarts so that they can run on openshift.

Notes : we're using the PropertiesLauncher here as a main class - the reason we are doing that is because we can build the spring-boot jar and then run it without any modifications.     I've tried a number of different ways to bundle the sapidoc3/sapjco3 JARs into the fat JAR and I haven't been successful at all because of the renaming issue.     We're packaging the .so and the sapidoc3/sapjco3 JARs up here into /deployments/lib and we can do that without renaming them, and then passing the location along in a classpath file to the launcher script.

These changes should be easily portable to the 4 branch, nothing other than the name of the main class is hard coded.