### PR TITLE
Provide similar workflow as OCP one

### DIFF
--- a/spring-boot/sap-idoc-destination-spring-boot/README.md
+++ b/spring-boot/sap-idoc-destination-spring-boot/README.md
@@ -100,8 +100,8 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-idoc-destination-spring-boot` directory.
-2. Run `mvn clean install` to build the quick start.
-3. Run `mvn spring-boot:run` to start the Camel runtime.
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
 4. In the console observe the contents of the IDoc processed by the route.
 5. Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
 6. Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 

--- a/spring-boot/sap-idoc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-idoc-destination-spring-boot/pom.xml
@@ -206,5 +206,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-idoclist-destination-spring-boot/README.md
+++ b/spring-boot/sap-idoclist-destination-spring-boot/README.md
@@ -100,11 +100,11 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-idoclist-destination-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* In the console observe the contents of the IDoc processed by the route.
-* Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
-* Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. In the console observe the contents of the IDoc processed by the route.
+5. Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
+6. Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-idoclist-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-idoclist-destination-spring-boot/pom.xml
@@ -196,5 +196,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-idoclist-server-spring-boot/README.md
+++ b/spring-boot/sap-idoclist-server-spring-boot/README.md
@@ -172,15 +172,15 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-idoclist-server-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* Invoke the camel route from SAP:  
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. Invoke the camel route from SAP:  
   a.Run the `ZFLCUSTOMER_CREATEFROMDATA01` program.  
   b.Using the SAP GUI, run transaction `SM58`, the Transactional RFC Monitor:   
     i. 		Display the outstanding transactions (Program > Execute).  
     ii.		Select the transaction destined for the `QUICKSTART`.  
     iii.	Execute the transaction to send the requests (Edit > Execute LUW).  
-* In the console observe the IDoc received by the endpoint.  
+5. In the console observe the IDoc received by the endpoint.  
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-idoclist-server-spring-boot/pom.xml
+++ b/spring-boot/sap-idoclist-server-spring-boot/pom.xml
@@ -130,8 +130,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-
 		</plugins>
 	</build>
 	<profiles>
@@ -193,6 +191,32 @@
 								<goals>
 									<goal>resource</goal>
 									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
 								</goals>
 							</execution>
 						</executions>

--- a/spring-boot/sap-qidoc-destination-spring-boot/README.md
+++ b/spring-boot/sap-qidoc-destination-spring-boot/README.md
@@ -98,15 +98,15 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-qidoc-destination-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* In the console observe the contents of the IDoc processed by the route.
-* Execute the queued IDocs waiting in the inbound queue `QUICKSTARTQUEUE`. Using the SAP GUI, run transaction `SMQ2`, the Inbound Queue qRFC Monitor:  
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. In the console observe the contents of the IDoc processed by the route.
+5. Execute the queued IDocs waiting in the inbound queue `QUICKSTARTQUEUE`. Using the SAP GUI, run transaction `SMQ2`, the Inbound Queue qRFC Monitor:  
     a. Select the `QUICKSTARTQUEUE` queue.  
     b. Display the queue contents (Edit > Display Selection).  
     c. Select the entry for your Client connection and activate the queue (Edit > Activate).  
-* Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
-* Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
+6. Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
+7. Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-qidoc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qidoc-destination-spring-boot/pom.xml
@@ -196,5 +196,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-qidoclist-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qidoclist-destination-spring-boot/pom.xml
@@ -196,5 +196,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-qrfc-destination-spring-boot/README.md
+++ b/spring-boot/sap-qrfc-destination-spring-boot/README.md
@@ -59,15 +59,15 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-qrfc-destination-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* In the console observe the contents of the requests processed by the route.
-* Execute the queued requests waiting in the inbound queue `QUICKSTARTQUEUE`. Using the SAP GUI, run transaction `SMQ2`, the Inbound Queue qRFC Monitor:  
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. In the console observe the contents of the requests processed by the route.
+5. Execute the queued requests waiting in the inbound queue `QUICKSTARTQUEUE`. Using the SAP GUI, run transaction `SMQ2`, the Inbound Queue qRFC Monitor:  
     a. Select the `QUICKSTARTQUEUE` queue.  
     b. Display the queue contents (Edit > Display Selection).  
     c. Select the entry for your Client connection and activate the queue (Edit > Activate).  
-* Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
-* Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
+6. Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
+7. Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-qrfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-qrfc-destination-spring-boot/pom.xml
@@ -198,5 +198,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-srfc-destination-spring-boot/README.md
+++ b/spring-boot/sap-srfc-destination-spring-boot/README.md
@@ -59,9 +59,9 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-srfc-destination-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* In the console observe the response returned by the endpoint.
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. In the console observe the response returned by the endpoint.
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-srfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-srfc-destination-spring-boot/pom.xml
@@ -198,5 +198,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-srfc-server-spring-boot/README.md
+++ b/spring-boot/sap-srfc-server-spring-boot/README.md
@@ -131,11 +131,11 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-srfc-server-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* Invoke the camel route from SAP by running the `ZBAPI_FLCUST_GETLIST` program.
-* In the console observe the request and response received and returned by the endpoint.  
-* Compare this response with the received data displayed by the ABAP program.   
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. Invoke the camel route from SAP by running the `ZBAPI_FLCUST_GETLIST` program.
+5. In the console observe the request and response received and returned by the endpoint.  
+6. Compare this response with the received data displayed by the ABAP program.   
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-srfc-server-spring-boot/pom.xml
+++ b/spring-boot/sap-srfc-server-spring-boot/pom.xml
@@ -198,5 +198,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-trfc-destination-spring-boot/README.md
+++ b/spring-boot/sap-trfc-destination-spring-boot/README.md
@@ -61,11 +61,11 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-trfc-destination-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* In the console observe the contents of the requests processed by the route.
-* Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
-* Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. In the console observe the contents of the requests processed by the route.
+5. Using the SAP GUI, run transaction `SE16`, Data Browser, and display the contents of the table `SCUSTOM`.
+6. Search the table (Edit > Find..) for the newly created Customer records: `Fred Flintstone`, `Wilma Flintstone`, `Barney Rubble`, and `Betty Rubble`. 
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-trfc-destination-spring-boot/pom.xml
+++ b/spring-boot/sap-trfc-destination-spring-boot/pom.xml
@@ -198,5 +198,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>

--- a/spring-boot/sap-trfc-server-spring-boot/README.md
+++ b/spring-boot/sap-trfc-server-spring-boot/README.md
@@ -142,10 +142,10 @@ Build and Run the Quickstart
 To build and run the quick start:
 
 1. Change your working directory to the `sap-trfc-server-spring-boot` directory.
-* Run `mvn clean install` to build the quick start.
-* Run `mvn spring-boot:run` to start the Camel runtime.
-* Invoke the camel route from SAP:  Run the `ZBAPI_FLCUST_CREATEFROMDATA` program.  
-* In the console observe the requests received by the endpoint.  
+2. Run `mvn clean install` to build the quick start or `mvn clean install -Pjar` to build a runnable jar.
+3. Run `mvn spring-boot:run` or `java -jar -Dloader.path=lib/ target/<jar_file>.jar` to start the Camel runtime.
+4. Invoke the camel route from SAP:  Run the `ZBAPI_FLCUST_CREATEFROMDATA` program.  
+5. In the console observe the requests received by the endpoint.  
 
 Deployment to OpenShift
 -----------------------

--- a/spring-boot/sap-trfc-server-spring-boot/pom.xml
+++ b/spring-boot/sap-trfc-server-spring-boot/pom.xml
@@ -198,5 +198,31 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<property>
+					<name>jar</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<layout>ZIP</layout>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>repackage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
The `<layout>ZIP</layout>` is similar to `<JAVA_MAIN_CLASS>org.springframework.boot.loader.PropertiesLauncher</JAVA_MAIN_CLASS>` in OCP profile, in this way jar can be run via `java -jar` without issues.