### PR TITLE
Use the most recent camel-spring-boot productized version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependency versions -->
-        <camel-spring-boot-version>4.14.2.redhat-00001</camel-spring-boot-version>
-        <camel-version>4.14.2.redhat-00001</camel-version>
+        <camel-spring-boot-version>4.14.2.redhat-00003</camel-spring-boot-version>
+        <camel-version>4.14.2.redhat-00002</camel-version>
         <spring-boot-version>3.5.7</spring-boot-version>
         <slf4j-api-version>2.0.17</slf4j-api-version>
         <sapjco3-version>3.1.12</sapjco3-version>


### PR DESCRIPTION
Use most recent camel-spring-boot - it's necessary because the camel-spring-boot-bom was not available in the first two successful builds.