### PR TITLE
Use productized 4.18.0 versions of camel/camel-spring-boot; update spring-boot to 3.5.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependency versions -->
-        <camel-spring-boot-version>4.14.4.redhat-00006</camel-spring-boot-version>
-        <camel-version>4.14.4.redhat-00004</camel-version>
-        <spring-boot-version>3.5.10</spring-boot-version>
+        <camel-spring-boot-version>4.18.0.redhat-00001</camel-spring-boot-version>
+        <camel-version>4.18.0.redhat-00002</camel-version>
+        <spring-boot-version>3.5.11</spring-boot-version>
         <slf4j-api-version>2.0.17</slf4j-api-version>
         <sapjco3-version>3.1.13</sapjco3-version>
         <sapidoc3-version>3.1.4</sapidoc3-version>


### PR DESCRIPTION
Use productized 4.18.0 versions of camel/camel-spring-boot; update spring-boot to 3.5.11
