### PR TITLE
Fix version properties to align with CS1 MRRC build numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependency versions -->
-        <camel-spring-boot-version>4.18.3.redhat-00001</camel-spring-boot-version>
-        <camel-version>4.18.3.redhat-00001</camel-version>
+        <camel-spring-boot-version>4.18.3.redhat-00005</camel-spring-boot-version>
+        <camel-version>4.18.3.redhat-00004</camel-version>
         <spring-boot-version>3.5.16</spring-boot-version>
         <slf4j-api-version>2.0.17</slf4j-api-version>
         <sapjco3-version>3.1.13</sapjco3-version>


### PR DESCRIPTION
## Summary
- camel-version: 4.18.3.redhat-00001 -> 4.18.3.redhat-00004
- camel-spring-boot-version: 4.18.3.redhat-00001 -> 4.18.3.redhat-00005
